### PR TITLE
Fix the link between configured systems and profiles

### DIFF
--- a/spec/models/manageiq/providers/cloud_automation_manager/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cloud_automation_manager/configuration_manager/refresher_spec.rb
@@ -50,6 +50,11 @@ describe ManageIQ::Providers::CloudAutomationManager::ConfigurationManager::Refr
         :type     => "ManageIQ::Providers::CloudAutomationManager::ConfigurationManager::ConfiguredSystem",
         :hostname => "citidemo",
       )
+
+      expect(configured_system.configuration_profile).to have_attributes(
+        :manager_ref => "5e1887e5a2d364001dab98f6",
+        :name        => "Azure Create disk storage"
+      )
     end
   end
 end


### PR DESCRIPTION
Instead of putting the templateId in the ipaddress column we should be setting the configuration_profile_id properly in the refresher.